### PR TITLE
Intent経由での実行に対応

### DIFF
--- a/model.rb
+++ b/model.rb
@@ -1,0 +1,1 @@
+require_relative 'model/shindanmaker'

--- a/model/shindanmaker.rb
+++ b/model/shindanmaker.rb
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+module Plugin::ShindanMaker
+  class Shindan < Diva::Model
+    register :shindanmaker_shindan, name: '診断メーカー'
+
+    field.int :id, required: true
+
+    handle %r[^https?://shindanmaker\.com/[0-9]+] do |uri|
+      begin
+        match = uri.to_s.match(/^https?:\/\/shindanmaker\.com\/([0-9]+)/)
+        Plugin::ShindanMaker::Shindan.new(id: match[1])
+      rescue
+        raise Diva::DivaError, "診断URLが処理できない形式です： #{uri}"
+      end
+    end
+
+    def uri
+      Diva::URI.new("https://shindanmaker.com/#{id}")
+    end
+  end
+end


### PR DESCRIPTION
最近のmikutterで実行できなくなっていたので、Intent経由で実行できるような実装を追加しました。  
ModelはURLハンドリングのためだけに定義したものです。

一応、IntentとDiva Modelが出揃ったバージョンが3.6あたりなのでそのように分岐を入れていますが、3.8.6でしか確認は取っていません。